### PR TITLE
Add idempotent order API and status-lite endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.next/

--- a/app/api/orders/[id]/route.ts
+++ b/app/api/orders/[id]/route.ts
@@ -14,15 +14,23 @@ function supabaseAdmin() {
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+type MaybePromise<T> = T | Promise<T>;
+
+type RouteParams = { id: string };
+
 type RouteContext = {
-  params?: {
-    id?: string;
-  };
+  params: MaybePromise<RouteParams>;
 };
+
+const isPromise = <T>(value: MaybePromise<T>): value is Promise<T> =>
+  typeof (value as PromiseLike<T>).then === 'function';
 
 export async function GET(_req: NextRequest, context: RouteContext) {
   try {
-    const id = context.params?.id;
+    const params = isPromise(context.params)
+      ? await context.params
+      : context.params;
+    const id = params?.id;
     if (!id || !UUID_REGEX.test(id)) {
       return NextResponse.json({ error: 'id inválido' }, { status: 400 });
     }

--- a/app/api/orders/[id]/route.ts
+++ b/app/api/orders/[id]/route.ts
@@ -43,7 +43,8 @@ export async function GET(_req: NextRequest, context: RouteContext) {
     }
 
     return NextResponse.json({ order: data as OrderRecord });
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message || 'error' }, { status: 500 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/orders/[id]/route.ts
+++ b/app/api/orders/[id]/route.ts
@@ -14,23 +14,15 @@ function supabaseAdmin() {
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-type MaybePromise<T> = T | Promise<T>;
-
 type RouteParams = { id: string };
 
 type RouteContext = {
-  params: MaybePromise<RouteParams>;
+  params: Promise<RouteParams>;
 };
-
-const isPromise = <T>(value: MaybePromise<T>): value is Promise<T> =>
-  typeof (value as PromiseLike<T>).then === 'function';
 
 export async function GET(_req: NextRequest, context: RouteContext) {
   try {
-    const params = isPromise(context.params)
-      ? await context.params
-      : context.params;
-    const id = params?.id;
+    const { id } = await context.params;
     if (!id || !UUID_REGEX.test(id)) {
       return NextResponse.json({ error: 'id inválido' }, { status: 400 });
     }

--- a/app/api/orders/[id]/status/route.ts
+++ b/app/api/orders/[id]/status/route.ts
@@ -15,15 +15,23 @@ function supabaseAdmin() {
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ALLOWED_STATUS: ReadonlyArray<OrderStatus> = ['queued', 'in_kitchen', 'ready', 'delivered'];
 
+type MaybePromise<T> = T | Promise<T>;
+
+type RouteParams = { id: string };
+
 type RouteContext = {
-  params?: {
-    id?: string;
-  };
+  params: MaybePromise<RouteParams>;
 };
+
+const isPromise = <T>(value: MaybePromise<T>): value is Promise<T> =>
+  typeof (value as PromiseLike<T>).then === 'function';
 
 export async function PATCH(req: NextRequest, context: RouteContext) {
   try {
-    const id = context.params?.id;
+    const params = isPromise(context.params)
+      ? await context.params
+      : context.params;
+    const id = params?.id;
     if (!id || !UUID_REGEX.test(id)) {
       return NextResponse.json({ error: 'id inválido' }, { status: 400 });
     }

--- a/app/api/orders/[id]/status/route.ts
+++ b/app/api/orders/[id]/status/route.ts
@@ -15,23 +15,15 @@ function supabaseAdmin() {
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 const ALLOWED_STATUS: ReadonlyArray<OrderStatus> = ['queued', 'in_kitchen', 'ready', 'delivered'];
 
-type MaybePromise<T> = T | Promise<T>;
-
 type RouteParams = { id: string };
 
 type RouteContext = {
-  params: MaybePromise<RouteParams>;
+  params: Promise<RouteParams>;
 };
-
-const isPromise = <T>(value: MaybePromise<T>): value is Promise<T> =>
-  typeof (value as PromiseLike<T>).then === 'function';
 
 export async function PATCH(req: NextRequest, context: RouteContext) {
   try {
-    const params = isPromise(context.params)
-      ? await context.params
-      : context.params;
-    const id = params?.id;
+    const { id } = await context.params;
     if (!id || !UUID_REGEX.test(id)) {
       return NextResponse.json({ error: 'id inválido' }, { status: 400 });
     }

--- a/app/api/orders/[id]/status/route.ts
+++ b/app/api/orders/[id]/status/route.ts
@@ -55,7 +55,8 @@ export async function PATCH(req: NextRequest, context: RouteContext) {
     }
 
     return NextResponse.json({ ok: true });
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message || 'error' }, { status: 500 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/orders/kds/route.ts
+++ b/app/api/orders/kds/route.ts
@@ -24,7 +24,8 @@ export async function GET() {
 
     if (error) return NextResponse.json({ error: error.message }, { status: 500 });
     return NextResponse.json({ orders: data });
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message || 'error' }, { status: 500 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/payments/mp/create/route.ts
+++ b/app/api/payments/mp/create/route.ts
@@ -62,7 +62,8 @@ export async function POST(req: Request) {
     // Links posibles: init_point (prod) y sandbox_init_point (sandbox)
     const url = data.init_point || data.sandbox_init_point;
     return NextResponse.json({ preferenceId: data.id, url });
-  } catch (e: any) {
-    return NextResponse.json({ error: e.message || 'error' }, { status: 500 });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'error';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/app/api/payments/mp/webhook/route.ts
+++ b/app/api/payments/mp/webhook/route.ts
@@ -62,8 +62,8 @@ export async function GET(req: Request) {
     }
 
     return NextResponse.json({ ok: true });
-  } catch (e: any) {
-    console.error('MP webhook error:', e);
+  } catch (error) {
+    console.error('MP webhook error:', error);
     // Aun así responde 200 para evitar tormenta de reintentos si es un bug temporal
     return NextResponse.json({ ok: true });
   }

--- a/src/app/api/orders/[id]/status-lite/route.ts
+++ b/src/app/api/orders/[id]/status-lite/route.ts
@@ -3,8 +3,9 @@ import { createClient } from '@supabase/supabase-js';
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { OrderStatus } from '@/types/order';
+import type { Database } from '@/types/supabase';
 
-type SupabaseAdminClient = SupabaseClient<Record<string, unknown>>;
+type SupabaseAdminClient = SupabaseClient<Database>;
 
 type OrderStatusLiteRow = {
   status: OrderStatus;
@@ -17,7 +18,7 @@ function supabaseAdmin(): SupabaseAdminClient {
   if (!url || !serviceRole) {
     throw new Error('Supabase admin credentials are not configured.');
   }
-  return createClient<unknown>(url, serviceRole, {
+  return createClient<Database>(url, serviceRole, {
     auth: { persistSession: false },
   });
 }

--- a/src/app/api/orders/[id]/status-lite/route.ts
+++ b/src/app/api/orders/[id]/status-lite/route.ts
@@ -18,15 +18,23 @@ function supabaseAdmin(): SupabaseAdminClient {
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+type MaybePromise<T> = T | Promise<T>;
+
+type RouteParams = { id: string };
+
 type RouteContext = {
-  params?: {
-    id?: string;
-  };
+  params: MaybePromise<RouteParams>;
 };
+
+const isPromise = <T>(value: MaybePromise<T>): value is Promise<T> =>
+  typeof (value as PromiseLike<T>).then === 'function';
 
 export async function GET(_req: NextRequest, context: RouteContext) {
   try {
-    const id = context.params?.id;
+    const params = isPromise(context.params)
+      ? await context.params
+      : context.params;
+    const id = params?.id;
     if (!id || !UUID_REGEX.test(id)) {
       return NextResponse.json({ error: 'id inválido' }, { status: 400 });
     }

--- a/src/app/api/orders/[id]/status-lite/route.ts
+++ b/src/app/api/orders/[id]/status-lite/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@supabase/supabase-js';
+
+function supabaseAdmin() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceRole) {
+    throw new Error('Supabase admin credentials are not configured.');
+  }
+  return createClient(url, serviceRole);
+}
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+type RouteContext = {
+  params?: {
+    id?: string;
+  };
+};
+
+export async function GET(_req: NextRequest, context: RouteContext) {
+  try {
+    const id = context.params?.id;
+    if (!id || !UUID_REGEX.test(id)) {
+      return NextResponse.json({ error: 'id inválido' }, { status: 400 });
+    }
+
+    const supa = supabaseAdmin();
+    const { data, error } = await supa
+      .from('orders')
+      .select('status, paid_at')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    if (!data) {
+      return NextResponse.json({ error: 'Orden no encontrada' }, { status: 404 });
+    }
+
+    return NextResponse.json({ status: data.status, paid_at: data.paid_at });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'error';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/orders/[id]/status-lite/route.ts
+++ b/src/app/api/orders/[id]/status-lite/route.ts
@@ -1,13 +1,19 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
-function supabaseAdmin() {
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+type SupabaseAdminClient = SupabaseClient<unknown>;
+
+function supabaseAdmin(): SupabaseAdminClient {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const serviceRole = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !serviceRole) {
     throw new Error('Supabase admin credentials are not configured.');
   }
-  return createClient(url, serviceRole);
+  return createClient<unknown>(url, serviceRole, {
+    auth: { persistSession: false },
+  });
 }
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/src/app/api/orders/[id]/status-lite/route.ts
+++ b/src/app/api/orders/[id]/status-lite/route.ts
@@ -2,8 +2,14 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@supabase/supabase-js';
 
 import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrderStatus } from '@/types/order';
 
-type SupabaseAdminClient = SupabaseClient<unknown>;
+type SupabaseAdminClient = SupabaseClient<Record<string, unknown>>;
+
+type OrderStatusLiteRow = {
+  status: OrderStatus;
+  paid_at: string | null;
+};
 
 function supabaseAdmin(): SupabaseAdminClient {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -44,7 +50,7 @@ export async function GET(_req: NextRequest, context: RouteContext) {
       .from('orders')
       .select('status, paid_at')
       .eq('id', id)
-      .maybeSingle();
+      .maybeSingle<OrderStatusLiteRow>();
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 });

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -3,25 +3,19 @@ import { createClient } from '@supabase/supabase-js';
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Money, OrderItem, OrderPayload, Totals } from '@/types/order';
+import type {
+  AuditResponsePayload,
+  Database,
+} from '@/types/supabase';
 
-type AuditResponsePayload = { ok: true; order_id: string };
-type AuditPayload = {
-  request?: OrderPayload;
-  response?: AuditResponsePayload;
-} | null;
-
-type AuditLogRow = {
-  id: string;
-  order_id: string | null;
-  payload: AuditPayload;
-};
+type AuditLogRow = Database['public']['Tables']['audit_logs']['Row'];
 
 type MaybeSingle<T> = {
   data: T | null;
   error: { message: string; code?: string } | null;
 };
 
-type SupabaseAdminClient = SupabaseClient<unknown>;
+type SupabaseAdminClient = SupabaseClient<Database>;
 
 function supabaseAdmin(): SupabaseAdminClient {
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -29,7 +23,7 @@ function supabaseAdmin(): SupabaseAdminClient {
   if (!url || !serviceRole) {
     throw new Error('Supabase admin credentials are not configured.');
   }
-  return createClient<unknown>(url, serviceRole, {
+  return createClient<Database>(url, serviceRole, {
     auth: { persistSession: false },
   });
 }

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -1,0 +1,111 @@
+import type { OrderPayload, OrderStatus, PaymentStatus, OrderItem } from '@/types/order';
+
+type JsonPrimitive = string | number | boolean | null;
+export type Json = JsonPrimitive | JsonPrimitive[] | { [key: string]: Json };
+
+export type AuditResponsePayload = { ok: true; order_id: string };
+
+export type AuditPayload = {
+  request?: OrderPayload;
+  response?: AuditResponsePayload;
+} | null;
+
+type Timestamp = string;
+
+type OrdersRow = {
+  id: string;
+  created_at: Timestamp;
+  customer_name: string;
+  customer_email: string | null;
+  service: OrderPayload['service'];
+  delivery_zone: NonNullable<OrderPayload['deliveryZone']> | null;
+  notes: string | null;
+  subtotal_cents: number;
+  shipping_cents: number;
+  tip_cents: number;
+  total_cents: number;
+  payment_status: PaymentStatus;
+  status: OrderStatus;
+  paid_at: Timestamp | null;
+};
+
+type OrdersInsert = {
+  id?: string;
+  created_at?: Timestamp;
+  customer_name: string;
+  customer_email?: string | null;
+  service: OrderPayload['service'];
+  delivery_zone?: NonNullable<OrderPayload['deliveryZone']> | null;
+  notes?: string | null;
+  subtotal_cents: number;
+  shipping_cents: number;
+  tip_cents: number;
+  total_cents: number;
+  payment_status?: PaymentStatus;
+  status?: OrderStatus;
+  paid_at?: Timestamp | null;
+};
+
+type OrdersUpdate = Partial<OrdersInsert>;
+
+type OrderItemsRow = {
+  id: string;
+  created_at: Timestamp;
+  order_id: string;
+  slot: OrderItem['slot'];
+  name: string;
+  price_cents: number;
+};
+
+type OrderItemsInsert = {
+  id?: string;
+  created_at?: Timestamp;
+  order_id: string;
+  slot: OrderItem['slot'];
+  name: string;
+  price_cents: number;
+};
+
+type OrderItemsUpdate = Partial<OrderItemsInsert>;
+
+type AuditLogsRow = {
+  id: string;
+  created_at: Timestamp;
+  type: string;
+  idempotency_key: string | null;
+  order_id: string | null;
+  payload: AuditPayload;
+};
+
+type AuditLogsInsert = {
+  id?: string;
+  created_at?: Timestamp;
+  type?: string;
+  idempotency_key?: string | null;
+  order_id?: string | null;
+  payload?: AuditPayload;
+};
+
+type AuditLogsUpdate = Partial<AuditLogsInsert>;
+
+export type Database = {
+  public: {
+    Tables: {
+      orders: {
+        Row: OrdersRow;
+        Insert: OrdersInsert;
+        Update: OrdersUpdate;
+      };
+      order_items: {
+        Row: OrderItemsRow;
+        Insert: OrderItemsInsert;
+        Update: OrderItemsUpdate;
+      };
+      audit_logs: {
+        Row: AuditLogsRow;
+        Insert: AuditLogsInsert;
+        Update: AuditLogsUpdate;
+      };
+    };
+  };
+};


### PR DESCRIPTION
## Summary
- replace the order creation API with an idempotent implementation that writes orders, order items, and audit logs before returning `{ ok, order_id }`
- add a lightweight `/api/orders/[id]/status-lite` endpoint that exposes the order status and `paid_at` timestamp
- update the POS client to send an idempotency key, consume the new response shape, and ignore node/build artifacts via `.gitignore`

## Testing
- `npm run lint` *(fails: existing `@typescript-eslint/no-explicit-any` violations in legacy API/UI files)*

------
https://chatgpt.com/codex/tasks/task_e_68d58f0f21788333b3f4a82247e5764a